### PR TITLE
Add using root certificate in external package

### DIFF
--- a/external/config.go
+++ b/external/config.go
@@ -88,6 +88,9 @@ type Config struct {
 	// PublicCertPath is a OS-path for the private HTTPS certificate.
 	PrivateCertPath string
 
+	// CACertPath is a OS-path for root certificate.
+	CACertPath string
+
 	// NoHTTPS ignores HTTPS if set.
 	NoHTTPS bool
 
@@ -145,6 +148,7 @@ func NewConfig(prefix string) func() *Config {
 		tlsVersion              = config.String(p("tls.version"), "1.2", "TLS version")
 		tlsPublicCert           = config.String(p("tls.cert.public"), "", "path to a public client TLS cert")
 		tlsPrivateCert          = config.String(p("tls.cert.private"), "", "path to a private client TLS cert")
+		tlsRootCert             = config.String(p("tls.cert.root"), "", "path to a root CA cert")
 		metricsCollect          = config.Bool(p("metrics.collect"), false, "enables gathering metrics in Prometheus format")
 	)
 
@@ -161,6 +165,7 @@ func NewConfig(prefix string) func() *Config {
 			PrivateCertPath:         *tlsPrivateCert,
 			ForceInsecureSkipVerify: *forceInsecureSkipVerify,
 			PublicCertPath:          *tlsPublicCert,
+			CACertPath:              *tlsRootCert,
 			Metrics: ConfigMetrics{
 				Collect: *metricsCollect,
 			},

--- a/external/transport.go
+++ b/external/transport.go
@@ -2,6 +2,8 @@ package external
 
 import (
 	"crypto/tls"
+	"crypto/x509"
+	"io/ioutil"
 	"net/http"
 )
 
@@ -10,6 +12,14 @@ func newDefaultTransport(cfg *Config) (http.RoundTripper, error) {
 	insecureTLS := cfg.NoHTTPS
 	tlsConfig := &tls.Config{ //nolint:gosec
 		MinVersion: castTLSVersion(cfg.MinVersionTLS),
+	}
+	if cfg.CACertPath != "" {
+		caCert, err := ioutil.ReadFile(cfg.CACertPath)
+		if err != nil {
+			return nil, err
+		}
+		tlsConfig.RootCAs = x509.NewCertPool()
+		tlsConfig.RootCAs.AppendCertsFromPEM(caCert)
 	}
 	if cfg.PrivateCertPath != "" || cfg.PublicCertPath != "" {
 		insecureTLS = false


### PR DESCRIPTION
A certificate authority can issue multiple certificates in the form of a tree structure. A root certificate is the top-most certificate of the tree, the private key of which is used to "sign" other certificates. All certificates signed by the root certificate, with the "CA" field set to true, inherit the trustworthiness of the root certificate—a signature by a root certificate is somewhat analogous to "notarizing" identity in the physical world. Such a certificate is called an intermediate certificate or subordinate CA certificate. Certificates further down the tree also depend on the trustworthiness of the intermediates.